### PR TITLE
add formatpkg to format all files in a package

### DIFF
--- a/.julia-config
+++ b/.julia-config
@@ -1,0 +1,4 @@
+# .julia-config for the DocumentFormat package
+IndentWidth = 4
+UseTab = false
+AlignAfterOpenBracket = Align

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -5,7 +5,7 @@ import CSTParser: EXPR, OPERATOR, IDENTIFIER, PUNCTUATION
 import CSTParser: UnaryOpCall, UnarySyntaxOpCall, BinaryOpCall, BinarySyntaxOpCall
 import CSTParser: trailing_ws_length, precedence
 
-export format
+export format, formatpkg
 const cst = CSTParser
 
 include("options.jl")
@@ -30,22 +30,126 @@ mutable struct FormatState
     indent::Int
     config::FormatConfig
 end
-FormatState(str) = FormatState(str, 0, [], get_line_ranges(str), 0, FormatConfig())
 
-
+FormatState(str, config) = FormatState(str, 0, [], get_line_ranges(str), 0, config)
+FormatState(str) = FormatState(str, FormatConfig())
 
 include("operators.jl")
 include("indents.jl")
 include("utils.jl")
 
-function format(str::String)
+function format(str::String, config = FormatConfig())
     x = CSTParser.parse(str, true)
-    F = FormatState(str)
+    F = FormatState(str, config)
     format(x, F)
     F.config.StripLineEnds && strip_empty_line_ends(F)
     F.config.NewLineEOF && end_file_newline(F)
     apply(str, F)
 end
+
+"""
+    formatpkg(pkg::String; kwargs...)
+
+Format the package `pkg` either given as the name of the package
+or as a full path to the package.
+
+**Keywords**:
+* `config::String` - Path to the config file to use. If not set, will look for a
+  `.julia-config` in the package directory and if not found will use the default
+  config
+* `force::Bool` - Format files even if the package repository is in a dirty state, defaults to `false`.
+"""
+function formatpkg(pkg::String; configpath=nothing, force=false)
+    # TODO: Better exceptions
+    # Figure out path to package
+    path = if isdir(Pkg.dir(pkg))
+        Pkg.dir(pkg)
+    elseif isdir(pkg)
+        pkg
+    else
+        error("could not find the package $pkg")
+    end
+ 
+    # Check dirtiness of repo
+    gitrepo =
+        try
+            LibGit2.GitRepo(path)
+        catch
+            nothing
+        end
+    if gitrepo !== nothing
+        if LibGit2.isdirty(gitrepo) && !force
+            error("package repository at $path is dirty and `force = false`")
+        end
+    end
+
+    # Get the configuration
+    config = if configpath == nothing
+        pkgconfigpath = joinpath(path, ".julia-config")
+        if isfile(pkgconfigpath)
+            parse_format_settings(pkgconfigpath)
+        else
+            FormatConfig()
+        end
+    else
+        parse_format_settings(configpath)
+    end
+
+    # if f returns something, an error happened in f
+    function apply_to_julia_files_in_folder(f)
+        for (root, dirs, files) in walkdir(path)
+            for file in files
+                if endswith(file, ".jl")    
+                    jlpath = joinpath(root, file)
+                    err = f(jlpath)
+                    if err != nothing
+                        return err, jlpath
+                    end
+                end
+            end
+        end
+        return nothing, nothing
+    end
+
+    # Make sure we can parse each file in the package before doing any formatting
+    # TODO: Perhaps this is annoying if a user has scratch files in the repo, use .gitignore?
+    err, path_to_file_with_error = apply_to_julia_files_in_folder(
+        function(file)
+            try     
+                CSTParser.parse(readstring(file))
+            catch er
+                return er
+            end
+            return nothing
+        end
+    )
+    if err != nothing
+        error("error when parsing $path_to_file_with_error, no formatting done, error: \n",
+              sprint(Base.showerror, err))
+    end
+
+    # Ok, all files parsed correctly, let's do the formatting
+    err, path_to_file_with_error = apply_to_julia_files_in_folder(
+        function(file)
+            oldstr = readstring(file)
+            newstr = format(oldstr, config)
+            # Check that newstr parses TODO: Should this be an option to `format`?
+            try
+                CSTParser.parse(newstr)
+            catch e
+                error("internal error: the formatted file failed to parse, error: \n",
+                      sprint(Base.showerror, e))
+            end
+            open(file, "w") do f
+                print(f, newstr)
+            end
+        end
+    )
+
+    # All files are formatted, we are happy
+    return 
+end
+    
 
 function format(x::EXPR{T}, F::FormatState) where T
     if T <: IndentEXPR

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
-using DocumentFormat.format
+using DocumentFormat: format, formatpkg
 using Base.Test
-
-
-# write your own tests here
 
 @testset "All" begin
 @testset "basic" begin
@@ -114,6 +111,13 @@ end
                     end""") == str
     end
 end
+end
+
+@testset "formatpkg DocumentFormat" begin
+    mktempdir() do path
+        cp(joinpath(@__DIR__, ".."), joinpath(path, "DocumentFormat"))
+        formatpkg(joinpath(path, "DocumentFormat"); force = true)
+    end
 end
 
 include("test_formatconfig.jl")


### PR DESCRIPTION
New function `formatpkg` that formats all files in a package. Does some checking that everything can be parsed beforehand but not sure if that can be annoying if you have scrap files in your package directory. Adds a test that copies this package to a temp folder and tries to format it but it fails because of a BoundsError in the formatting code.

The function checks for a file `.julia-config` in the repo and in that case uses that one so that people can have their own `.julia-config` for packages. Not sure if that is a good idea either. Added one to this package just as an example.