### PR TITLE
fix broke sortperm() call for 0.7 compat

### DIFF
--- a/src/formatconfig.jl
+++ b/src/formatconfig.jl
@@ -31,7 +31,7 @@ end
 const __config_settings_docstr = let
     default_config = FormatConfig()
     io = IOBuffer()
-    sortperm_fields = sortperm(fieldnames(FormatConfig))
+    sortperm_fields = sortperm(collect(fieldnames(FormatConfig)))
     for i in sortperm_fields
         setting, typ = fieldnames(FormatConfig)[i], FormatConfig.types[i]
         default_value = getfield(default_config, setting)


### PR DESCRIPTION
Julia 0.7 changes the behavior of `fieldnames` so that it returns a tuple instead of an array (JuliaLang/julia#25725). However, `sortperm` isn't defined for tuples, breaking compilation. This just converts the tuple returned by `fieldnames` to an array.