### PR TITLE
[WIP] upgrade to Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
+
+matrix:
+    allow_failures:
+        - nightly
+
 notifications:
   email: false
-git:
-  depth: 99999999
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
@@ -30,6 +33,6 @@ git:
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("DocumentFormat"); Pkg.test("DocumentFormat"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("DocumentFormat")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'import Pkg; cd(Pkg.Pkg2.dir("DocumentFormat")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("DocumentFormat")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'import Pkg; cd(Pkg.Pkg2.dir("DocumentFormat")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
-CSTParser 0.3.0
-Tokenize 0.4.0
+julia 0.7
+CSTParser 
+Tokenize 

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -142,7 +142,7 @@ function formatpkg(pkg::String; configpath=nothing, force=false)
     err, path_to_file_with_error = apply_to_julia_files_in_folder(
         function(file)
             try     
-                CSTParser.parse(readstring(file))
+                CSTParser.parse(read(file, String))
             catch er
                 return er
             end
@@ -157,7 +157,7 @@ function formatpkg(pkg::String; configpath=nothing, force=false)
     # Ok, all files parsed correctly, let's do the formatting
     err, path_to_file_with_error = apply_to_julia_files_in_folder(
         function(file)
-            oldstr = readstring(file)
+            oldstr = read(file, String)
             newstr = format(oldstr, config)
             # Check that newstr parses TODO: Should this be an option to `format`?
             try

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-using DocumentFormat: format, formatpkg
-using Base.Test
+import DocumentFormat: format, formatpkg
+using Test
 
 @testset "All" begin
 @testset "basic" begin

--- a/test/test_formatconfig.jl
+++ b/test/test_formatconfig.jl
@@ -1,5 +1,5 @@
 module TestFormatConfig
-using Base.Test
+using Test
 using DocumentFormat
 import DocumentFormat: parse_format_settings, Options, FormatConfigParserException
 


### PR DESCRIPTION
still have some test errors.
I am using the master branch of CSTParser.jl

```
   [7] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1071 [inlined]
   [8] macro expansion at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:6 [inlined]
   [9] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
   [10] top-level scope at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:5
func call: Test Failed at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:86
  Expression: format("func(a=1,b; c=1)") == "func(a = 1, b; c = 1)"
   Evaluated: "func(a=1, b; c=1)" == "func(a = 1, b; c = 1)"
Stacktrace:
 [1] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1085 [inlined]
 [2] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1071 [inlined]
 [3] macro expansion at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:6 [inlined]
 [4] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
 [5] top-level scope at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:5
let: Test Failed at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:233
  Expression: format("let x = X, y = Y\n    arg\nend") == str
   Evaluated: "            let x = X, y = Y\narg\nend" == "let x = X, y = Y\n    arg\nend"
Stacktrace:
 [1] top-level scope at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:21
 [2] include at ./boot.jl:317 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1038
 [4] include(::Module, ::String) at ./sysimg.jl:29
 [5] include(::String) at ./client.jl:388
 [6] top-level scope at none:0
 [7] eval(::Module, ::Any) at ./boot.jl:319
 [8] macro expansion at ./logging.jl:317 [inlined]
 [9] exec_options(::Base.JLOptions) at ./client.jl:219
 [10] _start() at ./client.jl:421
let: Test Failed at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:237
  Expression: format("let x = X, y = Y\narg\nend") == str
   Evaluated: "            let x = X, y = Y\n    arg\nend" == "let x = X, y = Y\n    arg\nend"
Stacktrace:
 [1] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1070 [inlined]
 [2] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1074 [inlined]
 [3] macro expansion at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:6 [inlined]
 [4] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/Test/src/Test.jl:1083 [inlined]
 [5] top-level scope at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:5
Test Summary:      | Pass  Fail  Error  Total
All                |   97     3      1    101
  basic            |    1                   1
  tuples           |   10                  10
  curly            |    6                   6
  unary ops        |    1                   1
  conditional ops  |    5                   5
  binary ops       |   18                  18
  op chain         |    1                   1
  comparison chain |                 1      1
  colon op         |    6                   6
  func call        |    9     1            10
  indents          |    7                   7
  quote            |    3                   3
  for              |    6                   6
  while            |    3                   3
  let              |    3     2             5
  struct           |    3                   3
  mutable struct   |    3                   3
  try-catch        |   12                  12
ERROR: LoadError: Some tests did not pass: 97 passed, 3 failed, 1 errored, 0 broken.
in expression starting at /usr/people/jingpeng/.julia/dev/DocumentFormat/test/runtests.jl:4
ERROR: Package DocumentFormat errored during testing

```