### PR TITLE
WIP: add additional passes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.7
-CSTParser 0.4.1
+CSTParser 0.5.0
 Tokenize 0.5.2

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -22,13 +22,18 @@ function format(text)
     pass(x, state, curly_pass)
     state.offset = 0
     pass(x, state, call_pass)
+    state.offset = 0
+    pass(x, state, forloop_pass)
+    state.offset = 0
+    pass(x, state, doc_pass)
     sort!(state.edits, lt = (a,b) -> first(a.loc) < first(b.loc), rev = true)
+    #= @info state.edits =#
     for i = 1:length(state.edits)
         text = apply(text, state.edits[i])
     end
     text = indents(text)
     return text
-    
+
 end
 
 function pass(x::CSTParser.LeafNode, state, f = (x,edits)->nothing)
@@ -47,7 +52,7 @@ end
 
 function ensure_single_space_after(x, state, offset)
     if x.fullspan == last(x.span)
-        if x isa CSTParser.OPERATOR 
+        if x isa CSTParser.OPERATOR
             if length(x.span) > 1 && length(String(Expr(x))) == 1
                 push!(state.edits, Edit(offset + 1, " "))
             else

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -12,7 +12,7 @@ mutable struct State{T}
     edits::T
 end
 
-function format(text)
+function format(text; convert_iterator_ops=false)
     state = State(0, Edit[])
     x = CSTParser.parse(text, true)
     pass(x, state, operator_pass)
@@ -22,8 +22,10 @@ function format(text)
     pass(x, state, curly_pass)
     state.offset = 0
     pass(x, state, call_pass)
-    state.offset = 0
-    pass(x, state, forloop_pass)
+    if convert_iterator_ops
+        state.offset = 0
+        pass(x, state, forloop_pass)
+    end
     state.offset = 0
     pass(x, state, doc_pass)
     sort!(state.edits, lt = (a,b) -> first(a.loc) < first(b.loc), rev = true)

--- a/src/DocumentFormat.jl
+++ b/src/DocumentFormat.jl
@@ -53,9 +53,9 @@ end
 
 
 function ensure_single_space_after(x, state, offset)
-    if x.fullspan == last(x.span)
+    if x.fullspan == x.span
         if x isa CSTParser.OPERATOR
-            if length(x.span) > 1 && length(String(Expr(x))) == 1
+            if x.span > 1 && length(String(Expr(x))) == 1
                 push!(state.edits, Edit(offset + 1, " "))
             else
                 push!(state.edits, Edit(offset + x.fullspan, " "))
@@ -67,8 +67,8 @@ function ensure_single_space_after(x, state, offset)
 end
 
 function ensure_no_space_after(x, state, offset)
-    if x.fullspan != last(x.span)
-        push!(state.edits, Edit(offset .+(last(x.span)+1:x.fullspan), ""))
+    if x.fullspan != x.span
+        push!(state.edits, Edit(offset .+(x.span+1:x.fullspan), ""))
     end
 end
 

--- a/src/indents.jl
+++ b/src/indents.jl
@@ -72,11 +72,17 @@ function indent_pass(x, state)
             doc_strs = split(CSTParser.str_value(doc), "\n")
 
             state.offset += 4
-            for s in doc_strs
-                l = length(s)
-                a = CSTParser.LITERAL(l+1, 1:l, s, Tokens.STRING)
-                check_indent(a, state)
-                indent_pass(a, state)
+            for (i, s) in enumerate(doc_strs)
+                # Skip indenting lines of "".
+                # The final "" is associated with identing the
+                # trailing docstring triple quote
+                if s == "" && i != length(doc_strs)
+                    state.offset += 1
+                else
+                    a = CSTParser.LITERAL(length(s)+1, 1:length(s), s, Tokens.STRING)
+                    check_indent(a, state)
+                    indent_pass(a, state)
+                end
             end
             state.offset += 3
 

--- a/src/indents.jl
+++ b/src/indents.jl
@@ -69,7 +69,7 @@ function indent_pass(x, state)
             state.offset += x.args[1].fullspan
 
             doc = x.args[2]
-            doc_strs = split(doc.val, "\n")
+            doc_strs = split(CSTParser.str_value(doc), "\n")
 
             state.offset += 4
             for s in doc_strs

--- a/src/indents.jl
+++ b/src/indents.jl
@@ -68,24 +68,10 @@ function indent_pass(x, state)
         if x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}
             state.offset += x.args[1].fullspan
 
-            # Doc alignment cases:
-            #
-            # 1. """doc"""
-            # 2. """
-            #    doc
-            #    """
-            # 3. """doc
-            #    """
-            # 4. """
-            #    doc"""
-            #
-
             doc = x.args[2]
             doc_strs = split(doc.val, "\n")
 
-            # If true there is a newline after the initial triple quote
-            length(doc.val) + 8 == doc.fullspan ? (state.offset += 4) : (state.offset += 3)
-
+            state.offset += 4
             for s in doc_strs
                 l = length(s)
                 a = CSTParser.LITERAL(l+1, 1:l, s, Tokens.STRING)

--- a/src/indents.jl
+++ b/src/indents.jl
@@ -64,6 +64,21 @@ function indent_pass(x, state)
             check_indent(x.args[3], state)
             state.offset += x.args[3].fullspan
         end
+    elseif x isa CSTParser.EXPR{CSTParser.Do}
+        state.offset += x.args[1].fullspan + x.args[2].fullspan + x.args[3].fullspan
+        if x.args[4] isa CSTParser.EXPR{CSTParser.Block}
+            state.edits.indent += 1
+            for a in x.args[4]
+                check_indent(a, state)
+                indent_pass(a, state)
+            end
+            state.edits.indent -= 1
+            check_indent(x.args[5], state)
+            state.offset += x.args[5].fullspan
+        else
+            check_indent(x.args[4], state)
+            state.offset += x.args[4].fullspan
+        end
     elseif x isa CSTParser.EXPR{CSTParser.MacroCall}
         if x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}
             state.offset += x.args[1].fullspan

--- a/src/indents.jl
+++ b/src/indents.jl
@@ -84,7 +84,7 @@ function indent_pass(x, state)
             state.offset += x.args[1].fullspan
 
             doc = x.args[2]
-            doc_strs = split(CSTParser.str_value(doc), "\n")
+            doc_strs = split(str_value(doc), "\n")
 
             state.offset += 4
             for (i, s) in enumerate(doc_strs)
@@ -94,7 +94,7 @@ function indent_pass(x, state)
                 if s == "" && i != length(doc_strs)
                     state.offset += 1
                 else
-                    a = CSTParser.LITERAL(length(s)+1, 1:length(s), s, Tokens.STRING)
+                    a = CSTParser.LITERAL(length(s)+1, length(s), s, Tokens.STRING)
                     check_indent(a, state)
                     indent_pass(a, state)
                 end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -114,6 +114,7 @@ function CSTParser.str_value(x::CSTParser.PUNCTUATION)
     x.kind == Tokens.COMMA && return ","
     x.kind == Tokens.SEMICOLON && return ";"
     x.kind == Tokens.AT_SIGN && return "@"
+    x.kind == Tokens.DOT && return "."
     return ""
 end
 
@@ -130,37 +131,6 @@ function CSTParser.str_value(x::CSTParser.UnarySyntaxOpCall)
     s *= CSTParser.str_value(x.arg2)
     return s
 end
-
-#= function CSTParser.str_value(x::CSTParser.UnaryOpCall) =#
-#=     s = CSTParser.str_value(x.op) =#
-#=     s *= CSTParser.str_value(x.arg2) =#
-#=     return s =#
-#= end =#
-#=  =#
-#= function CSTParser.str_value(x::Union{CSTParser.BinaryOpCall, CSTParser.BinarySyntaxOpCall}) =#
-#=     s = CSTParser.str_value(x.arg1) =#
-#=     s *= CSTParser.str_value(x.op) =#
-#=     s *= CSTParser.str_value(x.arg2) =#
-#=     return s =#
-#= end =#
-#=  =#
-#= function CSTParser.str_value(x::CSTParser.WhereOpCall) =#
-#=     s = CSTParser.str_value(x.arg1) =#
-#=     s *= CSTParser.str_value(x.op) =#
-#=     for a in x.args =#
-#=         s *= CSTParser.str_value(a) =#
-#=     end =#
-#=     return s =#
-#= end =#
-#=  =#
-#= function CSTParser.str_value(x::CSTParser.ConditionalOpCall) =#
-#=     s = CSTParser.str_value(x.cond) =#
-#=     s *= CSTParser.str_value(x.op1) =#
-#=     s *= CSTParser.str_value(x.arg1) =#
-#=     s *= CSTParser.str_value(x.op2) =#
-#=     s *= CSTParser.str_value(x.arg2) =#
-#=     return s =#
-#= end =#
 
 function doc_pass(x, state)
     if x isa CSTParser.EXPR{CSTParser.MacroCall} && x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -105,7 +105,7 @@ end
 
 function doc_pass(x, state)
     if x isa CSTParser.EXPR{CSTParser.MacroCall} && x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}
-        # if the docstring is global align it to:
+        # Align global docstring to:
         #
         # """
         # doc
@@ -115,15 +115,14 @@ function doc_pass(x, state)
         offset = state.offset + x.args[1].fullspan
         doc = x.args[2]
         val = CSTParser.str_value(doc)
-        fname = x.args[3] |> CSTParser.get_name |> CSTParser.str_value
-        s = string(strip(val), "\n")
-        ds = string("\"\"\"\n", s, "\"\"\"\n")
+        s = strip(val, ['\n'])
+        ds = string("\"\"\"\n", s, "\n", "\"\"\"\n")
 
-        # check if docstring needs to be edited
+        # Check if docstring needs to be edited
         if length(ds) != doc.fullspan || s != val
-            # remove previous docstring
+            # Remove previous docstring
             push!(state.edits, Edit(offset+1:offset+doc.fullspan, ""))
-            # append newly formatted docstring
+            # Append newly formatted docstring
             push!(state.edits, Edit(offset, ds))
         end
     end

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -104,7 +104,7 @@ function forloop_pass(x, state)
 end
 
 # TODO: move this to CSTParser?
-function CSTParser.str_value(x::CSTParser.PUNCTUATION)
+function str_value(x::CSTParser.PUNCTUATION)
     x.kind == Tokens.LPAREN && return "("
     x.kind == Tokens.LBRACE && return "{"
     x.kind == Tokens.LSQUARE && return "["
@@ -118,19 +118,20 @@ function CSTParser.str_value(x::CSTParser.PUNCTUATION)
     return ""
 end
 
-function CSTParser.str_value(x::CSTParser.EXPR)
+function str_value(x::CSTParser.EXPR)
     s = ""
     for a in x
-        s *= CSTParser.str_value(a)
+        s *= str_value(a)
     end
     return s
 end
 
-function CSTParser.str_value(x::CSTParser.UnarySyntaxOpCall)
-    s = CSTParser.str_value(x.arg1)
-    s *= CSTParser.str_value(x.arg2)
+function str_value(x::CSTParser.UnarySyntaxOpCall)
+    s = str_value(x.arg1)
+    s *= str_value(x.arg2)
     return s
 end
+str_value(x) = CSTParser.str_value(x)
 
 function doc_pass(x, state)
     if x isa CSTParser.EXPR{CSTParser.MacroCall} && x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}
@@ -144,7 +145,7 @@ function doc_pass(x, state)
         offset = state.offset + x.args[1].fullspan
         doc = x.args[2]
 
-        val = CSTParser.str_value(doc)
+        val = str_value(doc)
 
         s = strip(val, ['\n'])
         ds = string("\"\"\"\n", s, "\n", "\"\"\"\n")

--- a/src/passes.jl
+++ b/src/passes.jl
@@ -103,6 +103,65 @@ function forloop_pass(x, state)
     end
 end
 
+# TODO: move this to CSTParser?
+function CSTParser.str_value(x::CSTParser.PUNCTUATION)
+    x.kind == Tokens.LPAREN && return "("
+    x.kind == Tokens.LBRACE && return "{"
+    x.kind == Tokens.LSQUARE && return "["
+    x.kind == Tokens.RPAREN && return ")"
+    x.kind == Tokens.RBRACE && return "}"
+    x.kind == Tokens.RSQUARE && return "]"
+    x.kind == Tokens.COMMA && return ","
+    x.kind == Tokens.SEMICOLON && return ";"
+    x.kind == Tokens.AT_SIGN && return "@"
+    return ""
+end
+
+function CSTParser.str_value(x::CSTParser.EXPR)
+    s = ""
+    for a in x
+        s *= CSTParser.str_value(a)
+    end
+    return s
+end
+
+function CSTParser.str_value(x::CSTParser.UnarySyntaxOpCall)
+    s = CSTParser.str_value(x.arg1)
+    s *= CSTParser.str_value(x.arg2)
+    return s
+end
+
+#= function CSTParser.str_value(x::CSTParser.UnaryOpCall) =#
+#=     s = CSTParser.str_value(x.op) =#
+#=     s *= CSTParser.str_value(x.arg2) =#
+#=     return s =#
+#= end =#
+#=  =#
+#= function CSTParser.str_value(x::Union{CSTParser.BinaryOpCall, CSTParser.BinarySyntaxOpCall}) =#
+#=     s = CSTParser.str_value(x.arg1) =#
+#=     s *= CSTParser.str_value(x.op) =#
+#=     s *= CSTParser.str_value(x.arg2) =#
+#=     return s =#
+#= end =#
+#=  =#
+#= function CSTParser.str_value(x::CSTParser.WhereOpCall) =#
+#=     s = CSTParser.str_value(x.arg1) =#
+#=     s *= CSTParser.str_value(x.op) =#
+#=     for a in x.args =#
+#=         s *= CSTParser.str_value(a) =#
+#=     end =#
+#=     return s =#
+#= end =#
+#=  =#
+#= function CSTParser.str_value(x::CSTParser.ConditionalOpCall) =#
+#=     s = CSTParser.str_value(x.cond) =#
+#=     s *= CSTParser.str_value(x.op1) =#
+#=     s *= CSTParser.str_value(x.arg1) =#
+#=     s *= CSTParser.str_value(x.op2) =#
+#=     s *= CSTParser.str_value(x.arg2) =#
+#=     return s =#
+#= end =#
+
 function doc_pass(x, state)
     if x isa CSTParser.EXPR{CSTParser.MacroCall} && x.args[1] isa CSTParser.EXPR{CSTParser.GlobalRefDoc}
         # Align global docstring to:
@@ -114,7 +173,9 @@ function doc_pass(x, state)
         # If the doc is single quoted i.e. "doc", they will be replaced with triple quotes.
         offset = state.offset + x.args[1].fullspan
         doc = x.args[2]
+
         val = CSTParser.str_value(doc)
+
         s = strip(val, ['\n'])
         ds = string("\"\"\"\n", s, "\n", "\"\"\"\n")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -401,6 +401,30 @@ end
         20
     end""") == str
 
+    @test format("""
+    "doc
+    "
+    function f()
+        20
+    end""") == str
+    @test format("""
+    "
+    doc"
+    function f()
+        20
+    end""") == str
+    @test format("""
+    "doc"
+    function f()
+        20
+    end""") == str
+    @test format("""
+    " doc
+          "
+    function f()
+        20
+    end""") == str
+
     str = """
        begin
            \"\"\"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,21 @@ end
         end""") == str
 end
 
+@testset "do" begin
+    str = """
+    map(args) do x
+        y = 20
+        return x * y
+    end"""
+
+    @test format("""
+    map(args) do x
+      y = 20
+                        return x * y
+        end""") == str
+
+end
+
 @testset "for" begin
     str = """
     for iter in I
@@ -189,19 +204,19 @@ end
     @test format("""
     for iter=I, iter2 in I2
         arg
-    end""") == str
+    end""", convert_iterator_ops=true) == str
     @test format("""
     for iter =I, iter2 in I2
         arg
-    end""") == str
+    end""", convert_iterator_ops=true) == str
     @test format("""
     for iter =I, iter2 in I2
         arg
-    end""") == str
+    end""", convert_iterator_ops=true) == str
     @test format("""
     for iter = I, iter2 = I2
         arg
-    end""") == str
+    end""", convert_iterator_ops=true) == str
 end
 
 @testset "while" begin
@@ -370,27 +385,27 @@ end
 
 @testset "docs" begin
     str = """
-    \"\"\"
+    \"""
     doc
-    \"\"\"
+    \"""
     function f()
         20
     end"""
 
     @test format("""
-    \"\"\"doc
-    \"\"\"
+    \"""doc
+    \"""
     function f()
         20
     end""") == str
     @test format("""
-    \"\"\"
-    doc\"\"\"
+    \"""
+    doc\"""
     function f()
         20
     end""") == str
     @test format("""
-    \"\"\"doc\"\"\"
+    \"""doc\"""
     function f()
         20
     end""") == str
@@ -413,26 +428,33 @@ end
         20
     end""") == str
 
+    # tests indentation and correctly formatting a docstring with escapes
     str = """
        begin
-           \"\"\"
+           \"""
                f
 
            docstring for f
-           \"\"\"
+           :(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
+                                                \$(dict[:kwargs]...))::\$rtype
+           \$(dict[:body])
+           \"""
            function f()
                100
            end
        end"""
     @test format("""
        begin
-       \"\"\"
+       \"""
 
            f
 
        docstring for f
+       :(function \$(dict[:name]){\$(all_params...)}(\$(dict[:args]...);
+                                            \$(dict[:kwargs]...))::\$rtype
+       \$(dict[:body])
 
-       \"\"\"
+       \"""
        function f()
            100
        end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,15 @@ end
     let x = X, y = Y
     arg
     end""") == str
+
+    str = """
+    y, back = let
+        body
+    end"""
+    @test format("""
+    y,back = let
+      body
+    end""") == str
 end
 
 @testset "struct" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -394,12 +394,6 @@ end
     function f()
         20
     end""") == str
-    @test format("""
-    \"\"\" doc
-          \"\"\"
-    function f()
-        20
-    end""") == str
 
     @test format("""
     "doc
@@ -418,16 +412,12 @@ end
     function f()
         20
     end""") == str
-    @test format("""
-    " doc
-          "
-    function f()
-        20
-    end""") == str
 
     str = """
        begin
            \"\"\"
+               f
+
            docstring for f
            \"\"\"
            function f()
@@ -436,8 +426,13 @@ end
        end"""
     @test format("""
        begin
-       \"\"\" docstring for f
-                \"\"\"
+       \"\"\"
+
+           f
+
+       docstring for f
+
+       \"\"\"
        function f()
            100
        end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,38 +149,59 @@ end
 
 @testset "for" begin
     str = """
-    for iter = I
+    for iter in I
         arg
     end"""
     @test format("""
-    for iter = I
+    for iter in I
         arg
     end""") == str
     @test format("""
-    for iter = I
+    for iter in I
     arg
     end""") == str
     @test format("""
-    for iter = I
+    for iter in I
       arg
     end""") == str
 
     str = """
-    for iter = I, iter2 = I2
+    for iter in I, iter2 in I2
         arg
     end"""
     @test format("""
-    for iter = I, iter2 = I2
+    for iter in I, iter2 in I2
+        arg
+    end""") == str
+    @test format("""
+    for iter in I, iter2 in I2
+    arg
+    end""") == str
+    @test format("""
+    for iter in I, iter2 in I2
+            arg
+        end""") == str
+
+    str = """
+    for iter in I, iter2 in I2
+        arg
+    end"""
+    @test format("""
+    for iter=I, iter2 in I2
+        arg
+    end""") == str
+    @test format("""
+    for iter =I, iter2 in I2
+        arg
+    end""") == str
+    @test format("""
+    for iter =I, iter2 in I2
         arg
     end""") == str
     @test format("""
     for iter = I, iter2 = I2
-    arg
+        arg
     end""") == str
-    @test format("""
-    for iter = I, iter2 = I2
-            arg
-        end""") == str
 end
 
 @testset "while" begin
@@ -347,36 +368,40 @@ end
         end""") == str
 end
 
-@testset "Docs" begin
+@testset "docs" begin
     str = """
-       begin
-       \"\"\"
-       docstring for f\"\"\"
-       function f()
-           100
-       end
-       end
-       """
-    @test """
-       begin
-           \"\"\"
-           docstring for f\"\"\"
-           function f()
-               100
-           end
-       end
-       """ == format(str)
+    \"\"\"
+    doc
+    \"\"\"
+    function f()
+        20
+    end"""
+
+    @test format("""
+    \"\"\"doc
+    \"\"\"
+    function f()
+        20
+    end""") == str
+    @test format("""
+    \"\"\"
+    doc\"\"\"
+    function f()
+        20
+    end""") == str
+    @test format("""
+    \"\"\"doc\"\"\"
+    function f()
+        20
+    end""") == str
+    @test format("""
+    \"\"\" doc
+          \"\"\"
+    function f()
+        20
+    end""") == str
+
     str = """
-       begin
-       \"\"\"
-       docstring for f
-       \"\"\"
-       function f()
-           100
-       end
-       end
-       """
-    @test """
        begin
            \"\"\"
            docstring for f
@@ -384,42 +409,15 @@ end
            function f()
                100
            end
-       end
-       """ == format(str)
-    str = """
+       end"""
+    @test format("""
        begin
-       \"\"\"docstring for f
-       \"\"\"
+       \"\"\" docstring for f
+                \"\"\"
        function f()
            100
        end
-       end
-       """
-    @test """
-       begin
-           \"\"\"docstring for f
-           \"\"\"
-           function f()
-               100
-           end
-       end
-       """ == format(str)
-    str = """
-       begin
-       \"\"\"docstring for f\"\"\"
-       function f()
-           100
-       end
-       end
-       """
-    @test """
-       begin
-           \"\"\"docstring for f\"\"\"
-           function f()
-               100
-           end
-       end
-       """ == format(str)
+       end""") == str
 end
 
 end


### PR DESCRIPTION
add for loop pass, rewrites`=` in for loops to `in`
add docstring pass which normalizes all global docstrings to

```
"""
doc for f
"""
function f()
    ...
end
```

the above also simplifies indenting the initial line of the docstring.